### PR TITLE
feat: 피보호자 등록 기능 API 연동 및 UI 흐름 통합

### DIFF
--- a/app/my-wards/page.tsx
+++ b/app/my-wards/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import SidebarLayout from '../../components/SidebarLayout';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
@@ -44,6 +45,7 @@ const MOOD_COLORS: Record<string, string> = {
 };
 
 export default function MyWardsPage() {
+  const router = useRouter();
   const [wards, setWards] = useState<Ward[]>([]);
   const [stats, setStats] = useState<Stats>({
     total: 0,
@@ -81,7 +83,7 @@ export default function MyWardsPage() {
           localStorage.removeItem('admin_access_token');
           localStorage.removeItem('admin_refresh_token');
           localStorage.removeItem('admin_info');
-          window.location.href = '/login';
+          router.replace('/login');
           return;
         }
         throw new Error(`HTTP ${response.status}`);
@@ -104,7 +106,7 @@ export default function MyWardsPage() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     fetchMyWards();

--- a/components/ManualWardForm.tsx
+++ b/components/ManualWardForm.tsx
@@ -35,8 +35,9 @@ export default function ManualWardForm({
     birth_date: '',
     address: '',
   });
-  const [errors, setErrors] =
-    useState<Partial<Record<FieldKey | 'global', string>>>({});
+  const [errors, setErrors] = useState<
+    Partial<Record<FieldKey | 'global', string>>
+  >({});
   const [submitting, setSubmitting] = useState(false);
 
   const fields: Array<{
@@ -115,7 +116,11 @@ export default function ManualWardForm({
 
     if (phone) {
       const normalized = phone.replace(/-/g, '');
-      if (normalized.length < 7 || normalized.length > 15 || !/^[\d-]+$/.test(phone)) {
+      if (
+        normalized.length < 7 ||
+        normalized.length > 15 ||
+        !/^[\d-]+$/.test(phone)
+      ) {
         nextErrors.phone_number = '전화번호는 숫자/하이픈 7~15자리여야 합니다.';
       }
     }
@@ -123,7 +128,8 @@ export default function ManualWardForm({
     if (birth) {
       const date = new Date(birth);
       if (Number.isNaN(date.getTime())) {
-        nextErrors.birth_date = '생년월일 형식을 확인해주세요. (예: 1990-01-01)';
+        nextErrors.birth_date =
+          '생년월일 형식을 확인해주세요. (예: 1990-01-01)';
       }
     }
 
@@ -157,7 +163,8 @@ export default function ManualWardForm({
     } catch (error) {
       setErrors(prev => ({
         ...prev,
-        global: (error as Error).message || '등록에 실패했습니다. 다시 시도해주세요.',
+        global:
+          (error as Error).message || '등록에 실패했습니다. 다시 시도해주세요.',
       }));
     } finally {
       setSubmitting(false);

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -1,0 +1,4 @@
+export type AdminInfo = {
+  organizationId?: string;
+  organizationName?: string;
+};


### PR DESCRIPTION
- SidebarLayout 내 피보호자 등록 API(POST /v1/admin/wards) 호출 로직 구현
- CSV 업로드 및 직접 입력(Manual Submit) 핸들러 추가
- CSV 데이터 행별 순회 업로드 및 결과 요약(성공/실패 카운트) 알림 기능 구현
- 관리자 권한(Token, OrganizationId) 검증 및 로딩 상태 관리 추가

[상세 변경 사항]
- SidebarLayout.tsx: API 호출 핸들러(createWard, handleCsvUpload, handleManualSubmit) 구현 및 모달 연결
- CsvUploadPanel.tsx: 데이터 검증 및 수정 후 확인 업로드(onConfirm) 콜백 연동
- ManualWardForm.tsx: 단건 입력 데이터 유효성 검사 및 제출(onSubmit) 연동
- sample-wards.csv: 테스트용 샘플 데이터 추가

[비고]
- 성공적인 요청을 위해 localStorage 내 admin_info 및 유효한 토큰이 필요함
- 백엔드 새 API(/v1/admin/wards) 배포 상태 확인 필요

Closes #9