### PR TITLE
[Refactor] 대상자 목록 ID 타입 안정화 및 연동 현황 필터 로직 개선

### DIFF
--- a/hooks/useAuthedFetch.ts
+++ b/hooks/useAuthedFetch.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export class AuthError extends Error {
+  constructor(message = 'AUTH_ERROR') {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+type UseAuthedFetchParams<T> = {
+  deps: unknown[];
+  fetcher: (args: { token: string; signal: AbortSignal }) => Promise<T>;
+};
+
+type UseAuthedFetchResult<T> = {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useAuthedFetch<T>({
+  deps,
+  fetcher,
+}: UseAuthedFetchParams<T>): UseAuthedFetchResult<T> {
+  const router = useRouter();
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestSeqRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++requestSeqRef.current;
+    const controller = new AbortController();
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      const token = localStorage.getItem('admin_access_token');
+      if (!token) {
+        setError('로그인이 필요합니다.');
+        setLoading(false);
+        return;
+      }
+      try {
+        const result = await fetcher({ token, signal: controller.signal });
+        if (requestId !== requestSeqRef.current) return;
+        setData(result);
+      } catch (err) {
+        if (controller.signal.aborted || requestId !== requestSeqRef.current)
+          return;
+        if (err instanceof AuthError) {
+          localStorage.removeItem('admin_access_token');
+          localStorage.removeItem('admin_refresh_token');
+          localStorage.removeItem('admin_info');
+          router.replace('/login');
+          return;
+        }
+        setError((err as Error).message || '알 수 없는 오류가 발생했습니다.');
+      } finally {
+        if (!controller.signal.aborted && requestId === requestSeqRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
✨ 변경 사항
이 PR에서는 대상자 목록의 데이터 안정성을 위해 ID 타입을 문자열로 통일하고, 연동 현황 페이지의 필터링 로직을 보다 직관적으로 개선했습니다.

ID 타입 안정화 및 렌더링 오류 수정

Beneficiary 타입 및 상태 관리(selectedId)의 ID 타입을 number에서 string으로 전환했습니다.

API 응답 데이터가 불완전할 경우 발생하던 React의 Encountered two children with the same key, NaN 경고를 해결하기 위해 row-${index} 가드 로직을 추가했습니다.

테이블 컴포넌트의 Props 타입을 수정하여 선택 및 하이라이트 로직의 타입 일관성을 확보했습니다.

대상자 연동 현황 필터 로직 단순화

기본(전체) 탭에서 연동/미연동 대상자가 모두 노출되도록 필터 범위를 확대했습니다.

'미연동 대상자' 탭을 클릭했을 때만 isRegistered=false가 적용되도록 useMemo 내 계산 로직을 개선했습니다.

미연동 데이터가 기본 목록에서도 즉시 확인 가능해짐에 따라 UX가 향상되었습니다.

🔗 관련 이슈
Closes #16 