### PR TITLE
feat(grid): AI Agent 참여자 Grid에서 숨김 처리

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,9 +109,11 @@ const RoomTracks = ({
     { onlySubscribed: false },
   );
 
-  // Filter out admin participants (admins are invisible)
+  // Filter out admin and agent participants (they are invisible in grid)
   const tracks = allTracks.filter(
-    (track) => !track.participant.identity.startsWith('admin_'),
+    (track) =>
+      !track.participant.identity.startsWith('admin_') &&
+      !track.participant.identity.startsWith('agent-'),
   );
 
   const getParticipantId = (participant: any) =>
@@ -146,6 +148,11 @@ const RoomTracks = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tracks]);
+
+  // If no visible participants, render an EmptyTile to maintain grid structure
+  if (tracks.length === 0) {
+    return <EmptyTile />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- AI Agent(`agent-` prefix)를 Grid에서 필터링하여 숨김 처리
- 참여자가 없을 때 EmptyTile 렌더링으로 Grid 구조 유지

## 관련 이슈
Closes #20

## 변경 파일
- `app/page.tsx`

## 테스트
- [x] AI Agent가 Grid에 표시되지 않음 확인
- [x] 빈 Room에서 EmptyTile 정상 표시 확인