### PR TITLE
[Feature] 피보호자 상세페이지 UI 개선

### DIFF
--- a/app/beneficiaries/DetailModal.module.css
+++ b/app/beneficiaries/DetailModal.module.css
@@ -333,6 +333,11 @@
   background-color: #F7F9F2;
 }
 
+.editField:focus-within {
+  border-color: #8FA963;
+  box-shadow: 0 0 0 2px rgba(143, 169, 99, 0.2);
+}
+
 .editLabel {
   font-size: 14px;
   font-weight: 800;
@@ -353,6 +358,13 @@
   background-color: transparent;
   width: 100%;
   min-width: 0;
+}
+
+.editInput:focus,
+.editTextarea:focus,
+.editSelect:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 .editTextarea {
@@ -690,10 +702,9 @@
 .noteTextarea {
   width: 100%;
   min-height: 160px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  border: 1px solid var(--beneficiary-border-color);
-  background-color: #F7F9F2;
+  padding: 0;
+  border: none;
+  background-color: transparent;
   font-size: 17px;
   font-weight: 700;
   color: #4A5D23;
@@ -713,6 +724,18 @@
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 10px;
+}
+
+.noteField {
+  border: 1px solid var(--beneficiary-border-color);
+  border-radius: 16px;
+  padding: 14px 16px;
+  background-color: #F7F9F2;
+}
+
+.noteField:focus-within {
+  border-color: #8FA963;
+  box-shadow: 0 0 0 2px rgba(143, 169, 99, 0.2);
 }
 
 .sentimentNegative {

--- a/app/beneficiaries/DetailModal.tsx
+++ b/app/beneficiaries/DetailModal.tsx
@@ -608,20 +608,22 @@ export default function DetailModal({
               <div className={styles.cardHeader}>
                 <SectionTitle>참고 및 특이사항</SectionTitle>
               </div>
-              <textarea
-                className={styles.noteTextarea}
-                value={
-                  isEditing
-                    ? form.notes
-                    : detail.notes || '추가 메모가 없습니다.'
-                }
-                readOnly={!isEditing}
-                onChange={
-                  isEditing
-                    ? e => handleFieldChange('notes', e.target.value)
-                    : undefined
-                }
-              />
+              <div className={styles.noteField}>
+                <textarea
+                  className={styles.noteTextarea}
+                  value={
+                    isEditing
+                      ? form.notes
+                      : detail.notes || '추가 메모가 없습니다.'
+                  }
+                  readOnly={!isEditing}
+                  onChange={
+                    isEditing
+                      ? e => handleFieldChange('notes', e.target.value)
+                      : undefined
+                  }
+                />
+              </div>
             </div>
           </section>
 


### PR DESCRIPTION
## 📋 변경 사항
- 상세 모달의 레이아웃 밀도와 입력 필드 구조를 개선했습니다.
  - 섹션 헤더를 카드 내부로 이동하고, 필드 라벨을 key-value 형태로 정렬
  - 모달 너비 및 카드/섹션 여백을 줄여 전체 밀도 개선
  - 포커스 시 필드 박스(모듈) 테두리가 강조되도록 스타일 변경
- UI 전용 담당자/보호자 정보 영역 및 메모 표시 개선

## 스크린샷
<img width="1049" height="1044" alt="image" src="https://github.com/user-attachments/assets/85c574d3-6700-4e9d-92ef-d34f4b58733a" />


## 🔗 관련 이슈
Closes #38

## ✅ 체크리스트
- [ ] pre-commit 통과
- [x] 브랜치/커밋 규칙 준수
- [ ] 변경 사항 설명 및 테스트 방법 기재

## 🧪 테스트
- 미실행 (로컬 확인 예정)
