### PR TITLE
[Feature] 보호자 성함 필드 추가

### DIFF
--- a/app/beneficiaries/DetailModal.module.css
+++ b/app/beneficiaries/DetailModal.module.css
@@ -714,7 +714,7 @@
 
 .guardianGrid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 

--- a/app/beneficiaries/DetailModal.tsx
+++ b/app/beneficiaries/DetailModal.tsx
@@ -89,6 +89,7 @@ export default function DetailModal({
     notes: '',
   });
   const [guardianForm, setGuardianForm] = useState({
+    name: '',
     relation: '',
     contact: '',
   });
@@ -100,6 +101,7 @@ export default function DetailModal({
   const diseaseText = detail.diseases.join(', ');
   const defaultGuardianForm = useMemo(
     () => ({
+      name: '',
       relation: '',
       contact: '',
     }),
@@ -478,6 +480,27 @@ export default function DetailModal({
               </div>
               <div className={styles.guardianGrid}>
                 <div className={styles.editField}>
+                  <span className={styles.editLabel}>보호자 성함</span>
+                  <input
+                    className={styles.editInput}
+                    value={
+                      isEditing
+                        ? guardianForm.name
+                        : guardianForm.name || '홍길동'
+                    }
+                    readOnly={!isEditing}
+                    onChange={
+                      isEditing
+                        ? e =>
+                            setGuardianForm(prev => ({
+                              ...prev,
+                              name: e.target.value,
+                            }))
+                        : undefined
+                    }
+                  />
+                </div>
+                <div className={styles.editField}>
                   <span className={styles.editLabel}>보호자 관계</span>
                   {isEditing ? (
                     <select
@@ -498,7 +521,7 @@ export default function DetailModal({
                   ) : (
                     <input
                       className={styles.editInput}
-                      value={guardianForm.relation || '없음'}
+                      value={guardianForm.relation || '자녀'}
                       readOnly
                     />
                   )}
@@ -510,7 +533,7 @@ export default function DetailModal({
                     value={
                       isEditing
                         ? guardianForm.contact
-                        : guardianForm.contact || '-'
+                        : guardianForm.contact || '010-1234-5678'
                     }
                     readOnly={!isEditing}
                     onChange={


### PR DESCRIPTION
## 📋 변경 사항

- 보호자 정보 섹션에 보호자 성함 필드를 추가했습니다.
- 보호자 정보가 3개의 필드(성함, 관계, 연락처)로 한 줄에 표시됩니다.

### 상세 변경 사항
- guardianForm state에 name 필드 추가
- 보호자 정보 그리드를 2열에서 3열로 확장
- 보호자 성함 입력 필드 UI 추가

## 🔗 관련 이슈

Closes #46 

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] 변경 사항 설명 기재