### PR TITLE
fix(video): 풀스크린 비디오 품질 즉시 적용 개선

### DIFF
--- a/components/video/FullScreenVideo.tsx
+++ b/components/video/FullScreenVideo.tsx
@@ -88,25 +88,36 @@ export const FullScreenVideo = ({
       });
     };
 
-    // 즉시 요청
-    requestHighQuality('mount');
+    // 이미 HIGH면 추가 작업 불필요
+    const isAlreadyHigh = pub.videoQuality === VideoQuality.HIGH;
 
-    // 트랙이 attach되면 재요청
-    const handleAttached = () => {
-      console.log('[FullScreen] 트랙 attached, 재요청');
-      requestHighQuality('attached');
-    };
-    track?.on('attached', handleAttached);
+    let retryTimeouts: NodeJS.Timeout[] = [];
 
-    // 트랙이 이미 attach된 경우 바로 재요청
-    if (track?.attachedElements?.length > 0) {
-      requestHighQuality('already-attached');
+    if (isAlreadyHigh) {
+      console.log('[FullScreen] 이미 HIGH 품질, 추가 요청 불필요');
+    } else {
+      // HIGH가 아닐 때만 요청 및 retry
+      requestHighQuality('mount');
+
+      // 트랙이 이미 attach된 경우 바로 재요청
+      if (track?.attachedElements?.length > 0) {
+        requestHighQuality('already-attached');
+      }
+
+      // 서버 응답 대기를 위한 retry (500ms, 1s, 2s 후)
+      retryTimeouts = [500, 1000, 2000].map((delay, i) =>
+        setTimeout(() => requestHighQuality(`retry-${i + 1}`), delay)
+      );
     }
 
-    // 서버 응답 대기를 위한 retry (500ms, 1s, 2s 후)
-    const retryTimeouts = [500, 1000, 2000].map((delay, i) =>
-      setTimeout(() => requestHighQuality(`retry-${i + 1}`), delay)
-    );
+    // 트랙이 attach되면 재요청 (HIGH 아닐 때만)
+    const handleAttached = () => {
+      if (pub.videoQuality !== VideoQuality.HIGH) {
+        console.log('[FullScreen] 트랙 attached, 재요청');
+        requestHighQuality('attached');
+      }
+    };
+    track?.on('attached', handleAttached);
 
     // 🔍 비디오 크기 변경 감지
     const handleVideoDimensionsChanged = () => {


### PR DESCRIPTION
## 문제
- 풀스크린 비디오 클릭 시 품질이 즉시 HIGH로 적용되지 않음
- mount 시점에 `dimensions: undefined`로 나옴
- 약 10초 후에야 최대 화질로 갱신됨

## 원인
- 트랙이 아직 attach되지 않은 상태에서 품질 요청
- 서버 응답 대기 없이 한 번만 요청

## 해결
- `attached` 이벤트 리스너 추가하여 트랙 연결 시 재요청
- retry 로직 추가 (500ms, 1s, 2s 후 재요청)
- 이미 attach된 경우 즉시 재요청
- cleanup에서 타이머 및 리스너 정리

## 변경 파일
- `components/video/FullScreenVideo.tsx`

Closes #48