### PR TITLE
[Feature] 대상자 연동 완료 시 실시간 토스트 알림

### DIFF
--- a/app/beneficiaries/page.tsx
+++ b/app/beneficiaries/page.tsx
@@ -153,39 +153,70 @@ export default function BeneficiariesPage() {
     const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
     if (!apiBase) return;
 
-    const sseUrl = `${apiBase}/v1/events/stream`;
-    const eventSource = new EventSource(sseUrl);
-    eventSourceRef.current = eventSource;
+    let retryDelay = 1000;
+    let retryTimeout: NodeJS.Timeout | null = null;
+    let currentEventSource: EventSource | null = null;
 
-    eventSource.onmessage = event => {
-      try {
-        const data = JSON.parse(event.data);
+    const isWardRegisteredEvent = (
+      data: unknown,
+    ): data is WardRegisteredEvent => {
+      return (
+        typeof data === 'object' &&
+        data !== null &&
+        'type' in data &&
+        (data as { type: string }).type === 'ward-registered' &&
+        'wardName' in data &&
+        typeof (data as { wardName: unknown }).wardName === 'string'
+      );
+    };
 
-        if (data.type === 'ward-registered') {
-          const wardEvent = data as WardRegisteredEvent;
-          console.log('[Beneficiaries] Ward registered:', wardEvent.wardName);
+    const connect = () => {
+      const sseUrl = `${apiBase}/v1/events/stream`;
+      const eventSource = new EventSource(sseUrl);
+      currentEventSource = eventSource;
+      eventSourceRef.current = eventSource;
 
-          // 토스트 알림 표시
-          setToast({
-            isOpen: true,
-            message: `${wardEvent.wardName}님이 연동되었습니다`,
-            type: 'success',
-          });
+      eventSource.onopen = () => {
+        retryDelay = 1000; // 연결 성공 시 재시도 딜레이 초기화
+      };
 
-          // 목록 새로고침
-          setRefreshKey(prev => prev + 1);
+      eventSource.onmessage = event => {
+        try {
+          const data = JSON.parse(event.data);
+
+          if (isWardRegisteredEvent(data)) {
+            console.log('[Beneficiaries] Ward registered:', data.wardName);
+
+            setToast({
+              isOpen: true,
+              message: `${data.wardName}님이 연동되었습니다`,
+              type: 'success',
+            });
+
+            setRefreshKey(prev => prev + 1);
+          }
+        } catch (err) {
+          console.error('[Beneficiaries] SSE parse error:', err);
         }
-      } catch (err) {
-        console.error('[Beneficiaries] SSE parse error:', err);
-      }
+      };
+
+      eventSource.onerror = () => {
+        console.warn('[Beneficiaries] SSE connection error, reconnecting...');
+        eventSource.close();
+
+        // 지수 백오프로 재연결
+        retryTimeout = setTimeout(() => {
+          connect();
+        }, retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 30000);
+      };
     };
 
-    eventSource.onerror = () => {
-      console.warn('[Beneficiaries] SSE connection error, will reconnect...');
-    };
+    connect();
 
     return () => {
-      eventSource.close();
+      if (retryTimeout) clearTimeout(retryTimeout);
+      if (currentEventSource) currentEventSource.close();
       eventSourceRef.current = null;
     };
   }, []);

--- a/app/beneficiaries/page.tsx
+++ b/app/beneficiaries/page.tsx
@@ -18,6 +18,7 @@ import DetailModal, {
   type BeneficiarySummary,
 } from './DetailModal';
 import StatsSummary from '../../components/ui/StatsSummary';
+import Toast, { type ToastType } from '../../components/ui/Toast';
 import {
   RefreshIcon,
   UsersIcon,
@@ -92,6 +93,15 @@ const EMPTY_DETAIL: BeneficiaryDetail = {
 
 type SortOption = 'name' | 'lastCall-recent' | 'lastCall-old';
 
+// SSE 이벤트 타입 정의
+type WardRegisteredEvent = {
+  type: 'ward-registered';
+  organizationWardId: string;
+  organizationId: string;
+  wardName: string;
+  timestamp: string;
+};
+
 export default function BeneficiariesPage() {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -109,8 +119,16 @@ export default function BeneficiariesPage() {
   const [reinviting, setReinviting] = useState(false);
   const [staffList, setStaffList] = useState<Staff[]>([]);
 
+  // Toast state for ward registration notification
+  const [toast, setToast] = useState<{
+    isOpen: boolean;
+    message: string;
+    type: ToastType;
+  }>({ isOpen: false, message: '', type: 'success' });
+
   // Refs for scrolling to specific rows
   const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  const eventSourceRef = useRef<EventSource | null>(null);
 
   // Staff API hook
   const staffApi = useStaffApi();
@@ -128,6 +146,48 @@ export default function BeneficiariesPage() {
       }
     };
     fetchStaff();
+  }, []);
+
+  // SSE 연결: 대상자 연동 완료 이벤트 수신
+  useEffect(() => {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+    if (!apiBase) return;
+
+    const sseUrl = `${apiBase}/v1/events/stream`;
+    const eventSource = new EventSource(sseUrl);
+    eventSourceRef.current = eventSource;
+
+    eventSource.onmessage = event => {
+      try {
+        const data = JSON.parse(event.data);
+
+        if (data.type === 'ward-registered') {
+          const wardEvent = data as WardRegisteredEvent;
+          console.log('[Beneficiaries] Ward registered:', wardEvent.wardName);
+
+          // 토스트 알림 표시
+          setToast({
+            isOpen: true,
+            message: `${wardEvent.wardName}님이 연동되었습니다`,
+            type: 'success',
+          });
+
+          // 목록 새로고침
+          setRefreshKey(prev => prev + 1);
+        }
+      } catch (err) {
+        console.error('[Beneficiaries] SSE parse error:', err);
+      }
+    };
+
+    eventSource.onerror = () => {
+      console.warn('[Beneficiaries] SSE connection error, will reconnect...');
+    };
+
+    return () => {
+      eventSource.close();
+      eventSourceRef.current = null;
+    };
   }, []);
 
   // 디바운스된 검색어로 필터링 부담을 줄임
@@ -924,6 +984,14 @@ export default function BeneficiariesPage() {
           />
         )}
       </div>
+
+      {/* 연동 완료 토스트 알림 */}
+      <Toast
+        message={toast.message}
+        type={toast.type}
+        isOpen={toast.isOpen}
+        onClose={() => setToast(prev => ({ ...prev, isOpen: false }))}
+      />
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
## 📋 변경 사항

- `WardEvent` SSE 이벤트 타입 추가 (`ward-registered`)
- `emitWardEvent()` 메서드 추가
- 카카오 로그인 시 기관 대상자 연동 완료 이벤트 발행
- `findPendingOrganizationWardByEmail`에서 `name` 필드 반환 추가

## 🔗 관련 이슈

Closes #151

## ✅ 체크리스트
- [x] prettier 적용
- [x] 브랜치/커밋 규칙 준수