### PR TITLE
feat(locations): 지도 페이지 실시간 care alert 상태 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ next-env.d.ts
 # refactoring docs (local only)
 REFACTORING_PLAN.md
 REFACTORING_PROGRESS.md
+.claude/

--- a/app/locations/page.tsx
+++ b/app/locations/page.tsx
@@ -6,6 +6,7 @@ import { LocationMap, type WardLocation } from '../../components/LocationMap';
 import MonitoringSidebar from '../../components/monitoring/MonitoringSidebar';
 import { useApi } from '../../hooks/useApi';
 import { apiClient } from '../../lib/api-client';
+import { useLocationDangerSSE } from '../../hooks/useLocationDangerSSE';
 import DetailModal, {
   type BeneficiaryDetail,
   type BeneficiaryUpdatePayload,
@@ -147,7 +148,10 @@ export default function LocationsPage() {
     fetcher: (client, signal) => client.get('/v1/admin/locations', { signal }),
   });
 
-  const locations: WardLocation[] = useMemo(() => {
+  // 2. SSE for real-time danger state updates
+  const { getEffectiveStatus, connected: sseConnected } = useLocationDangerSSE();
+
+  const locationsRaw: WardLocation[] = useMemo(() => {
     if (!locationsDataRaw) return [];
     if (Array.isArray(locationsDataRaw)) return locationsDataRaw as WardLocation[];
     const response = locationsDataRaw as LocationsResponse;
@@ -155,10 +159,23 @@ export default function LocationsPage() {
     return [];
   }, [locationsDataRaw]);
 
+  // Apply SSE danger state to locations (SSE takes priority over API status)
+  const locations: WardLocation[] = useMemo(() => {
+    return locationsRaw.map(loc => ({
+      ...loc,
+      status: getEffectiveStatus(loc.wardId, loc.status),
+    }));
+  }, [locationsRaw, getEffectiveStatus]);
+
   useEffect(() => {
     const interval = setInterval(() => refetchLocations(), 30000);
     return () => clearInterval(interval);
   }, [refetchLocations]);
+
+  // Debug log for SSE connection
+  useEffect(() => {
+    console.log('[LocationsPage] SSE connected:', sseConnected);
+  }, [sseConnected]);
 
   // 2. Use Custom Hook for Details
   const { selectedData, detailError } = useBeneficiaryDetail(selectedWardId, locations);

--- a/app/monitoring/page.tsx
+++ b/app/monitoring/page.tsx
@@ -16,7 +16,7 @@ import {
   type RoomDangerState,
 } from '../../components/video';
 import { useRoomSSE, useMultiRoomSession } from '../../hooks';
-import { requestHighQuality, setRoomDanger } from '../../utils/roomApi';
+import { requestHighQuality, setRoomDanger, acknowledgeAllAlertsInRoom } from '../../utils/roomApi';
 import { API_BASE } from '../../lib/api-client';
 import type { RoomConnection } from '../../types/room';
 import styles from './page.module.css';
@@ -102,7 +102,8 @@ export default function Home() {
         // Only update if changed to avoid re-renders
         if (
           prev[roomName]?.isDanger === state.isDanger &&
-          prev[roomName]?.dangerCode === state.dangerCode
+          prev[roomName]?.dangerCode === state.dangerCode &&
+          prev[roomName]?.riskLevel === state.riskLevel
         ) {
           return prev;
         }
@@ -538,6 +539,7 @@ export default function Home() {
       key: string;
       connection?: RoomConnection;
       isDanger?: boolean;
+      riskLevel?: 'normal' | 'caution' | 'critical';
     }> = [];
 
     // If we have user rooms, put them first
@@ -584,6 +586,8 @@ export default function Home() {
 
   const handleClearDanger = () => {
     if (selectedRoomName) {
+      // Call both APIs: acknowledge all alerts and clear danger state
+      acknowledgeAllAlertsInRoom(selectedRoomName);
       setRoomDanger(selectedRoomName, false);
     }
   };
@@ -684,6 +688,7 @@ export default function Home() {
               }
               isFullscreenActive={showFullScreenVideo}
               isDanger={slot.isDanger}
+              riskLevel={slot.riskLevel}
             />
             {/* Render detail sidebar inside the selected room's LiveKitRoom context */}
             {selectedRoomName === slot.connection.roomName &&
@@ -697,6 +702,9 @@ export default function Home() {
                     isDanger={
                       dangerStates[slot.connection.roomName]?.isDanger ?? false
                     }
+                    riskLevel={
+                      dangerStates[slot.connection.roomName]?.riskLevel ?? 'normal'
+                    }
                     isHeaderHidden={isMonitoringFullscreen}
                   />
                   <ParticipantDetailSidebar
@@ -708,6 +716,9 @@ export default function Home() {
                     onClose={handleCloseSidebar}
                     isDanger={
                       dangerStates[slot.connection.roomName]?.isDanger ?? false
+                    }
+                    riskLevel={
+                      dangerStates[slot.connection.roomName]?.riskLevel ?? 'normal'
                     }
                     dangerCode={
                       dangerStates[slot.connection.roomName]?.dangerCode

--- a/components/video/FullScreenVideo.tsx
+++ b/components/video/FullScreenVideo.tsx
@@ -12,7 +12,15 @@ type FullScreenVideoProps = {
   participant: MockParticipant;
   videoTrackRef: any;
   isDanger?: boolean;
+  riskLevel?: 'normal' | 'caution' | 'critical';
   isHeaderHidden?: boolean;
+};
+
+// Color configurations based on risk level
+const RISK_COLORS = {
+  normal: { border: 'transparent', glow: 'transparent', dot: '#10b981' },
+  caution: { border: '#eab308', glow: 'rgba(234, 179, 8, 0.6)', dot: '#eab308' },
+  critical: { border: '#ef4444', glow: 'rgba(239, 68, 68, 0.6)', dot: '#ef4444' },
 };
 
 const VOLUME_STORAGE_KEY = 'fullscreen-volume';
@@ -43,8 +51,13 @@ export const FullScreenVideo = ({
   participant,
   videoTrackRef: externalVideoTrackRef,
   isDanger = false,
+  riskLevel = 'normal',
   isHeaderHidden = false,
 }: FullScreenVideoProps) => {
+  // Determine effective risk level based on riskLevel prop (isDanger is for backward compatibility)
+  const effectiveRiskLevel = riskLevel !== 'normal' ? riskLevel : (isDanger ? 'critical' : 'normal');
+  const colors = RISK_COLORS[effectiveRiskLevel];
+  const isAlert = effectiveRiskLevel !== 'normal';
   const room = useRoomContext();
   const [volume, setVolume] = useState(() => getStoredVolume());
   const [showVolumeSlider, setShowVolumeSlider] = useState(false);
@@ -360,23 +373,27 @@ export const FullScreenVideo = ({
               position: 'relative',
               borderRadius: '24px',
               overflow: 'hidden',
-              boxShadow: isDanger
-                ? '0 0 0 4px #ef4444, 0 0 40px rgba(239, 68, 68, 0.6), 0 40px 100px rgba(0, 0, 0, 0.6)'
+              boxShadow: isAlert
+                ? `0 0 0 4px ${colors.border}, 0 0 40px ${colors.glow}, 0 40px 100px rgba(0, 0, 0, 0.6)`
                 : '0 40px 100px rgba(0, 0, 0, 0.6)',
               background: '#000000',
               height: '90vh',
               aspectRatio: '9 / 16', // Maintains portrait aspect ratio
-              animation: isDanger
-                ? 'dangerPulse 1.5s ease-in-out infinite'
+              animation: isAlert
+                ? `${effectiveRiskLevel}Pulse 1.5s ease-in-out infinite`
                 : undefined,
             }}
           >
-            {isDanger && (
+            {isAlert && (
               <style>
                 {`
-                  @keyframes dangerPulse {
+                  @keyframes criticalPulse {
                     0%, 100% { box-shadow: 0 0 0 4px #ef4444, 0 0 40px rgba(239, 68, 68, 0.6), 0 40px 100px rgba(0, 0, 0, 0.6); }
                     50% { box-shadow: 0 0 0 6px #ef4444, 0 0 60px rgba(239, 68, 68, 0.8), 0 40px 100px rgba(0, 0, 0, 0.6); }
+                  }
+                  @keyframes cautionPulse {
+                    0%, 100% { box-shadow: 0 0 0 4px #eab308, 0 0 40px rgba(234, 179, 8, 0.6), 0 40px 100px rgba(0, 0, 0, 0.6); }
+                    50% { box-shadow: 0 0 0 6px #eab308, 0 0 60px rgba(234, 179, 8, 0.8), 0 40px 100px rgba(0, 0, 0, 0.6); }
                   }
                 `}
               </style>
@@ -443,8 +460,8 @@ export const FullScreenVideo = ({
                   width: '10px',
                   height: '10px',
                   borderRadius: '50%',
-                  background: isDanger ? '#ef4444' : '#10b981',
-                  animation: isDanger
+                  background: colors.dot,
+                  animation: isAlert
                     ? 'pulse 1s ease-in-out infinite'
                     : undefined,
                 }}

--- a/components/video/LiveTileOps.tsx
+++ b/components/video/LiveTileOps.tsx
@@ -14,7 +14,15 @@ export interface LiveTileOpsProps {
   onClick?: (roomName: string, participantId: string, trackRef: any) => void;
   participantId: string;
   isDanger?: boolean;
+  riskLevel?: 'normal' | 'caution' | 'critical';
 }
+
+// Color configurations based on risk level
+const RISK_COLORS = {
+  normal: { border: 'transparent', glow: 'transparent', dot: '#10b981' },
+  caution: { border: '#eab308', glow: 'rgba(234, 179, 8, 0.5)', dot: '#eab308' },
+  critical: { border: '#ef4444', glow: 'rgba(239, 68, 68, 0.5)', dot: '#ef4444' },
+};
 
 export const LiveTileOps = memo(function LiveTileOps({
   trackRef,
@@ -25,9 +33,15 @@ export const LiveTileOps = memo(function LiveTileOps({
   onClick,
   participantId,
   isDanger,
+  riskLevel = 'normal',
 }: LiveTileOpsProps) {
   const cameraOff = videoOff;
   const showVideo = !cameraOff && !suppressVideo;
+
+  // Determine effective risk level based on riskLevel prop (isDanger is for backward compatibility)
+  const effectiveRiskLevel = riskLevel !== 'normal' ? riskLevel : (isDanger ? 'critical' : 'normal');
+  const colors = RISK_COLORS[effectiveRiskLevel];
+  const isAlert = effectiveRiskLevel !== 'normal';
 
   const handleClick = () => {
     if (onClick) {
@@ -43,20 +57,24 @@ export const LiveTileOps = memo(function LiveTileOps({
         cursor: onClick ? 'pointer' : 'default',
         borderRadius: '12px',
         overflow: 'hidden',
-        boxShadow: isDanger
-          ? '0 0 0 3px #ef4444, 0 0 20px rgba(239, 68, 68, 0.5)'
+        boxShadow: isAlert
+          ? `0 0 0 3px ${colors.border}, 0 0 20px ${colors.glow}`
           : undefined,
-        animation: isDanger
-          ? 'dangerPulse 1.5s ease-in-out infinite'
+        animation: isAlert
+          ? `${effectiveRiskLevel}Pulse 1.5s ease-in-out infinite`
           : undefined,
       }}
       onClick={handleClick}
     >
       <style>
         {`
-          @keyframes dangerPulse {
+          @keyframes criticalPulse {
             0%, 100% { box-shadow: 0 0 0 3px #ef4444, 0 0 20px rgba(239, 68, 68, 0.5); }
             50% { box-shadow: 0 0 0 4px #ef4444, 0 0 30px rgba(239, 68, 68, 0.8); }
+          }
+          @keyframes cautionPulse {
+            0%, 100% { box-shadow: 0 0 0 3px #eab308, 0 0 20px rgba(234, 179, 8, 0.5); }
+            50% { box-shadow: 0 0 0 4px #eab308, 0 0 30px rgba(234, 179, 8, 0.8); }
           }
         `}
       </style>
@@ -88,8 +106,8 @@ export const LiveTileOps = memo(function LiveTileOps({
                 width: '8px',
                 height: '8px',
                 borderRadius: '50%',
-                backgroundColor: isDanger ? '#ef4444' : '#10b981',
-                animation: isDanger
+                backgroundColor: colors.dot,
+                animation: isAlert
                   ? 'pulse 1s ease-in-out infinite'
                   : undefined,
               }}

--- a/components/video/ParticipantDetailSidebar.tsx
+++ b/components/video/ParticipantDetailSidebar.tsx
@@ -31,6 +31,7 @@ type ParticipantDetailSidebarProps = {
   isTakeoverActive?: boolean;
   onToggleTakeover?: () => void;
   isDanger?: boolean;
+  riskLevel?: 'normal' | 'caution' | 'critical';
   dangerCode?: string; // 4-bit: 1000=deviceFall, 0100=personFall, 0010=loudVoice, 0001=emotion
   onClearDanger?: () => void;
   detectionInfo?: DetectionInfo | null;
@@ -53,6 +54,206 @@ type DetectionInfo = {
   type: string;
   severity: string;
   criteria: DetectionCriteria[];
+};
+
+// 센서 상태 타입
+type SensorStatusLevel = 'normal' | 'caution' | 'critical';
+
+type SensorState = {
+  status: SensorStatusLevel;
+  value: number; // 0-100 퍼센트 값
+  lastUpdated: number;
+  isLocked: boolean; // 주의/경고 시 값 고정
+  pendingValue?: number; // 잠금 상태에서 들어온 최신 값 (해제 시 적용)
+};
+
+type SensorStates = {
+  emotion: SensorState;
+  audio: SensorState;
+  motion: SensorState;
+  face: SensorState;
+};
+
+// sensor_status 토픽으로 수신되는 메시지 타입
+type SensorStatusMessage = {
+  timestamp: number;
+  wardId: string;
+  emotion?: {
+    status: SensorStatusLevel;
+    value: string;
+    confidence: number;
+  };
+  audio?: {
+    status: SensorStatusLevel;
+    level: number;
+    decibel: number;
+  };
+  motion?: {
+    status: SensorStatusLevel;
+    fallRisk: number;
+    isFreefalling: boolean;
+  };
+  face?: {
+    status: SensorStatusLevel;
+    isDetected: boolean;
+    faceY: number;
+  };
+};
+
+const SENSOR_LABELS: Record<keyof SensorStates, string> = {
+  emotion: '감정',
+  audio: '음성',
+  motion: '모션',
+  face: '얼굴',
+};
+
+// alertType → sensor 매핑
+const ALERT_TYPE_TO_SENSOR: Record<string, keyof SensorStates> = {
+  emotion: 'emotion',
+  device_fall: 'motion',
+  person_fall: 'face',
+  loud_voice: 'audio',
+};
+
+// 상태별 색상
+const SENSOR_STATUS_COLORS: Record<SensorStatusLevel, { dot: string; border: string; bg: string }> = {
+  normal: { dot: '#22c55e', border: '#e2e8f0', bg: '#ffffff' },
+  caution: { dot: '#eab308', border: '#eab308', bg: '#fefce8' },
+  critical: { dot: '#ef4444', border: '#ef4444', bg: '#fef2f2' },
+};
+
+// 센서 상태 표시 컴포넌트 (가로 막대그래프)
+const SensorStatusIndicator = ({
+  states,
+  onUnlock,
+}: {
+  states: SensorStates;
+  onUnlock?: (sensor: keyof SensorStates) => void;
+}) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        padding: '14px 16px',
+        background: '#ffffff',
+        borderRadius: '12px',
+        border: '1px solid #e2e8f0',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+      }}
+    >
+      {(Object.keys(states) as Array<keyof SensorStates>).map((sensor) => {
+        const state = states[sensor];
+        const colors = SENSOR_STATUS_COLORS[state.status];
+        const isAlert = state.status !== 'normal';
+
+        return (
+          <div
+            key={sensor}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+            }}
+          >
+            {/* 센서 라벨 */}
+            <span
+              style={{
+                width: '36px',
+                fontSize: '12px',
+                fontWeight: 600,
+                color: isAlert ? colors.dot : '#64748b',
+                flexShrink: 0,
+              }}
+            >
+              {SENSOR_LABELS[sensor]}
+            </span>
+
+            {/* 막대그래프 컨테이너 */}
+            <div
+              style={{
+                flex: 1,
+                height: '20px',
+                background: '#f1f5f9',
+                borderRadius: '10px',
+                overflow: 'hidden',
+                position: 'relative',
+                border: isAlert ? `1.5px solid ${colors.border}` : '1px solid #e2e8f0',
+              }}
+            >
+              {/* 막대 (값) */}
+              <div
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  height: '100%',
+                  width: `${state.value}%`,
+                  background: isAlert
+                    ? `linear-gradient(90deg, ${colors.dot}cc, ${colors.dot})`
+                    : 'linear-gradient(90deg, #22c55e99, #22c55e)',
+                  borderRadius: '10px',
+                  transition: state.isLocked ? 'none' : 'width 0.3s ease',
+                  animation: isAlert && state.status === 'critical' ? 'bar-pulse 1.5s infinite' : undefined,
+                }}
+              />
+              {/* 퍼센트 텍스트 */}
+              <span
+                style={{
+                  position: 'absolute',
+                  right: '8px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  fontSize: '11px',
+                  fontWeight: 700,
+                  color: state.value > 60 ? '#ffffff' : '#475569',
+                  textShadow: state.value > 60 ? '0 1px 2px rgba(0,0,0,0.3)' : 'none',
+                }}
+              >
+                {Math.round(state.value)}%
+              </span>
+            </div>
+
+            {/* 잠금 상태 표시 및 해제 버튼 */}
+            {state.isLocked ? (
+              <button
+                onClick={() => onUnlock?.(sensor)}
+                style={{
+                  padding: '4px 8px',
+                  fontSize: '11px',
+                  fontWeight: 600,
+                  color: '#ffffff',
+                  background: colors.dot,
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                  transition: 'all 0.2s',
+                }}
+                onMouseOver={(e) => {
+                  e.currentTarget.style.opacity = '0.8';
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.opacity = '1';
+                }}
+              >
+                해제
+              </button>
+            ) : (
+              <div style={{ width: '40px', flexShrink: 0 }} /> // 공간 유지
+            )}
+          </div>
+        );
+      })}
+      <style>{`
+        @keyframes bar-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.7; }
+        }
+      `}</style>
+    </div>
+  );
 };
 
 const hexToRgba = (hex: string, alpha = 1) => {
@@ -88,9 +289,8 @@ const InfoCard = ({
       style={{
         position: 'relative',
         background: '#ffffff',
-        border: `1px solid ${
-          highlight ? hexToRgba(color, 0.45) : 'rgba(226,232,240,1)'
-        }`,
+        border: `1px solid ${highlight ? hexToRgba(color, 0.45) : 'rgba(226,232,240,1)'
+          }`,
         borderRadius: '18px',
         padding: '14px 20px',
         boxShadow: highlight
@@ -161,8 +361,8 @@ const InfoCard = ({
 };
 
 // Helper function to highlight danger keywords
-const highlightDangerKeywords = (text: string) => {
-  const dangerKeywords = [
+const highlightDangerKeywords = (text: string, additionalKeywords: string[] = []) => {
+  const baseKeywords = [
     '도와주세요',
     '살려주세요',
     '아파',
@@ -187,6 +387,9 @@ const highlightDangerKeywords = (text: string) => {
     '먹었',
     '삼켰',
   ];
+
+  // 기본 키워드 + Agent에서 감지한 동적 키워드 합치기 (중복 제거)
+  const dangerKeywords = [...new Set([...baseKeywords, ...additionalKeywords])];
 
   let highlightedText: (string | JSX.Element)[] = [text];
 
@@ -345,6 +548,13 @@ const dangerCodeToDetectionInfo = (dangerCode: string): DetectionInfo | null => 
   };
 };
 
+// Border colors based on risk level
+const SIDEBAR_BORDER_COLORS = {
+  normal: 'rgba(148,163,184,0.35)',
+  caution: '#eab308',
+  critical: '#ef4444',
+};
+
 export const ParticipantDetailSidebar = ({
   participant,
   onClose,
@@ -353,6 +563,7 @@ export const ParticipantDetailSidebar = ({
   isTakeoverActive = false,
   onToggleTakeover,
   isDanger = false,
+  riskLevel = 'normal',
   dangerCode,
   onClearDanger,
   detectionInfo,
@@ -360,6 +571,10 @@ export const ParticipantDetailSidebar = ({
 }: ParticipantDetailSidebarProps) => {
   const isWarning = participant.status === 'WARNING';
   const accentColor = isWarning ? '#f87171' : '#38bdf8';
+
+  // Determine effective risk level for sidebar border
+  const effectiveRiskLevel = riskLevel !== 'normal' ? riskLevel : (isDanger ? 'critical' : 'normal');
+  const sidebarBorderColor = SIDEBAR_BORDER_COLORS[effectiveRiskLevel];
   const transcriptEndRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null); // Ref for chat scroll container
   const [transcripts, setTranscripts] = useState<Transcript[]>([]);
@@ -375,6 +590,196 @@ export const ParticipantDetailSidebar = ({
   // Detection info from DataChannel (agent alert_response)
   const [localDetectionInfo, setLocalDetectionInfo] =
     useState<DetectionInfo | null>(null);
+
+  // 센서 상태 (4개 센서)
+  const initialSensorState: SensorState = {
+    status: 'normal',
+    value: 0,
+    lastUpdated: Date.now(),
+    isLocked: false,
+  };
+  const [sensorStates, setSensorStates] = useState<SensorStates>({
+    emotion: initialSensorState,
+    audio: initialSensorState,
+    motion: initialSensorState,
+    face: initialSensorState,
+  });
+
+  // Agent에서 감지한 동적 키워드 리스트 (하이라이트용)
+  const [detectedKeywords, setDetectedKeywords] = useState<string[]>([]);
+
+  // 센서 상태 업데이트 함수 (값과 상태 모두 업데이트)
+  const updateSensorStatus = useCallback((
+    sensor: keyof SensorStates,
+    status: SensorStatusLevel,
+    value?: number
+  ) => {
+    setSensorStates(prev => {
+      const currentState = prev[sensor];
+
+      // 이미 잠금 상태면 pendingValue만 업데이트
+      if (currentState.isLocked) {
+        return {
+          ...prev,
+          [sensor]: {
+            ...currentState,
+            pendingValue: value ?? currentState.pendingValue,
+          },
+        };
+      }
+
+      const isAlert = status !== 'normal';
+
+      return {
+        ...prev,
+        [sensor]: {
+          status,
+          value: value ?? currentState.value,
+          lastUpdated: Date.now(),
+          isLocked: isAlert, // 주의/경고 시 자동 잠금
+          pendingValue: undefined, // 새로 잠금될 때 pending 클리어
+        },
+      };
+    });
+  }, []);
+
+  // 센서 값만 업데이트 (잠금 상태면 pendingValue에 저장)
+  const updateSensorValue = useCallback((
+    sensor: keyof SensorStates,
+    value: number
+  ) => {
+    setSensorStates(prev => {
+      const currentState = prev[sensor];
+
+      // 잠금 상태면 pendingValue에 저장 (해제 시 적용됨)
+      if (currentState.isLocked) {
+        return {
+          ...prev,
+          [sensor]: {
+            ...currentState,
+            pendingValue: value,
+          },
+        };
+      }
+
+      return {
+        ...prev,
+        [sensor]: {
+          ...currentState,
+          value,
+          lastUpdated: Date.now(),
+          pendingValue: undefined, // 정상 상태면 pending 클리어
+        },
+      };
+    });
+  }, []);
+
+  // 센서 잠금 해제 함수 (pendingValue가 있으면 적용) + API 호출
+  const unlockSensor = useCallback(async (sensor: keyof SensorStates) => {
+    // 1. 로컬 상태 먼저 업데이트 (UI 반응성)
+    setSensorStates(prev => {
+      const currentState = prev[sensor];
+      return {
+        ...prev,
+        [sensor]: {
+          ...currentState,
+          status: 'normal',
+          isLocked: false,
+          // pendingValue가 있으면 적용, 없으면 현재 값 유지
+          value: currentState.pendingValue ?? currentState.value,
+          pendingValue: undefined,
+          lastUpdated: Date.now(),
+        },
+      };
+    });
+
+    // 2. API 호출하여 DB의 alert acknowledge + room metadata 업데이트
+    if (roomName) {
+      try {
+        const token = localStorage.getItem('admin_access_token');
+        if (!token) {
+          console.warn('[Sidebar] No auth token for acknowledge API');
+          return;
+        }
+
+        const response = await fetch(`${API_BASE}/v1/guardians/alerts/acknowledge-by-type`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            roomName,
+            sensorType: sensor,
+          }),
+        });
+
+        if (!response.ok) {
+          console.error('[Sidebar] Failed to acknowledge by type:', response.status);
+        } else {
+          const result = await response.json();
+          console.log(`[Sidebar] Acknowledged ${sensor} alerts:`, result);
+
+          // 모든 alert이 해제되었으면 onClearDanger 호출 (UI 동기화)
+          if (result.acknowledgedCount > 0) {
+            // 다른 센서에 alert이 남아있는지 확인
+            const hasOtherLockedSensors = Object.entries(sensorStates).some(
+              ([key, state]) => key !== sensor && state.isLocked
+            );
+
+            if (!hasOtherLockedSensors) {
+              // 모든 센서가 해제됨 - onClearDanger 호출하여 Grid 테두리도 업데이트
+              onClearDanger?.();
+            }
+          }
+        }
+      } catch (error) {
+        console.error('[Sidebar] Error acknowledging by type:', error);
+      }
+    }
+  }, [roomName, sensorStates, onClearDanger]);
+
+  // 잠금 상태가 아닌 센서만 30초 후 자동으로 normal 상태로 복구
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const RESET_DELAY = 30000; // 30초
+
+      setSensorStates(prev => {
+        const updated = { ...prev };
+        let changed = false;
+
+        (Object.keys(prev) as Array<keyof SensorStates>).forEach(sensor => {
+          const state = prev[sensor];
+          // 잠금 상태가 아니고, normal이 아니고, 30초 지났으면 복구
+          if (!state.isLocked && state.status !== 'normal' && now - state.lastUpdated > RESET_DELAY) {
+            updated[sensor] = {
+              ...state,
+              status: 'normal',
+              lastUpdated: now,
+            };
+            changed = true;
+          }
+        });
+
+        return changed ? updated : prev;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  // isDanger가 false가 되면 모든 센서 상태 리셋
+  useEffect(() => {
+    if (!isDanger) {
+      setSensorStates({
+        emotion: initialSensorState,
+        audio: initialSensorState,
+        motion: initialSensorState,
+        face: initialSensorState,
+      });
+    }
+  }, [isDanger]);
 
   // Convert dangerCode to DetectionInfo if available
   const dangerCodeDetectionInfo = dangerCode
@@ -497,6 +902,179 @@ export const ParticipantDetailSidebar = ({
         if (topic === 'alert_response' && data.detectionInfo) {
           console.log('[Sidebar] Received detection info:', data.detectionInfo);
           setLocalDetectionInfo(data.detectionInfo);
+
+          // 센서 상태 업데이트
+          const alertType = data.alertType || data.detectionInfo?.type;
+          const riskLevel = data.riskLevel || data.severity || data.detectionInfo?.severity;
+
+          if (alertType && ALERT_TYPE_TO_SENSOR[alertType]) {
+            const sensor = ALERT_TYPE_TO_SENSOR[alertType];
+            let status: SensorStatusLevel = 'normal';
+
+            if (riskLevel === 'critical' || riskLevel === 'high') {
+              status = 'critical';
+            } else if (riskLevel === 'caution' || riskLevel === 'medium') {
+              status = 'caution';
+            }
+
+            console.log(`[Sidebar] Updating sensor ${sensor} to ${status}`);
+            updateSensorStatus(sensor, status);
+          }
+        }
+
+        // Handle care_alert topic directly
+        if (topic === 'care_alert' && data.alertType) {
+          const alertType = data.alertType;
+          const riskLevel = data.data?.payload?.riskLevel || data.severity;
+
+          if (ALERT_TYPE_TO_SENSOR[alertType]) {
+            const sensor = ALERT_TYPE_TO_SENSOR[alertType];
+            let status: SensorStatusLevel = 'normal';
+
+            if (riskLevel === 'critical' || riskLevel === 'high') {
+              status = 'critical';
+            } else if (riskLevel === 'caution' || riskLevel === 'medium') {
+              status = 'caution';
+            }
+
+            console.log(`[Sidebar] Care alert: ${sensor} -> ${status}`);
+            updateSensorStatus(sensor, status);
+          }
+        }
+
+        // Handle sensor_stream topic (iOS에서 보내는 실시간 센서 데이터)
+        // iOS 형식: { timestamp, emotion?: {...}, audio?: {...}, motion?: {...}, face?: {...} }
+        if (topic === 'sensor_stream') {
+          console.log('[Sidebar] sensor_stream received:', data);
+          // emotion 데이터 처리
+          if (data.emotion) {
+            const emotionValue = data.emotion.confidence !== undefined
+              ? Math.round(data.emotion.confidence * 100)
+              : undefined;
+            if (emotionValue !== undefined) {
+              updateSensorValue('emotion', emotionValue);
+            }
+          }
+
+          // audio 데이터 처리
+          if (data.audio) {
+            // level을 우선 사용 (0.0~1.0 -> 0~100%)
+            // decibel은 -160~0 dB 범위 (-60dB 이상을 유효 범위로 가정)
+            const audioValue = data.audio.level !== undefined
+              ? Math.round(data.audio.level * 100)
+              : (data.audio.decibel !== undefined
+                ? Math.min(100, Math.max(0, Math.round((data.audio.decibel + 60) * (100 / 60))))
+                : undefined);
+            if (audioValue !== undefined) {
+              updateSensorValue('audio', audioValue);
+            }
+          }
+
+          // motion 데이터 처리 (iOS는 camelCase: fallRisk)
+          if (data.motion) {
+            const motionValue = data.motion.fallRisk !== undefined
+              ? Math.round(data.motion.fallRisk * 100)
+              : undefined;
+            if (motionValue !== undefined) {
+              updateSensorValue('motion', motionValue);
+            }
+          }
+
+          // face 데이터 처리 (iOS는 camelCase: faceY, isDetected)
+          if (data.face) {
+            const faceValue = data.face.faceY !== undefined
+              ? Math.min(100, Math.max(0, Math.round(data.face.faceY * 100)))
+              : undefined;
+            if (faceValue !== undefined) {
+              updateSensorValue('face', faceValue);
+            }
+          }
+        }
+
+        // Handle sensor_status topic (Agent로부터 실시간 센서 상태 수신)
+        if (topic === 'sensor_status') {
+          const sensorData = data as SensorStatusMessage;
+
+          // emotion 센서 상태 업데이트
+          if (sensorData.emotion) {
+            const emotionValue = sensorData.emotion.confidence !== undefined
+              ? Math.round(sensorData.emotion.confidence * 100)
+              : undefined;
+
+            if (sensorData.emotion.status === 'normal') {
+              if (emotionValue !== undefined) updateSensorValue('emotion', emotionValue);
+            } else {
+              updateSensorStatus('emotion', sensorData.emotion.status, emotionValue);
+            }
+          }
+
+          // audio 센서 상태 업데이트
+          // level 우선 사용 (0.0~1.0 -> 0~100%), decibel은 -160~0 범위
+          if (sensorData.audio) {
+            const audioValue = sensorData.audio.level !== undefined
+              ? Math.round(sensorData.audio.level * 100)
+              : undefined;
+
+            if (sensorData.audio.status === 'normal') {
+              if (audioValue !== undefined) updateSensorValue('audio', audioValue);
+            } else {
+              updateSensorStatus('audio', sensorData.audio.status, audioValue);
+            }
+          }
+
+          // motion 센서 상태 업데이트
+          if (sensorData.motion) {
+            const motionValue = sensorData.motion.fallRisk !== undefined
+              ? Math.round(sensorData.motion.fallRisk * 100)
+              : undefined;
+
+            if (sensorData.motion.status === 'normal') {
+              if (motionValue !== undefined) updateSensorValue('motion', motionValue);
+            } else {
+              updateSensorStatus('motion', sensorData.motion.status, motionValue);
+            }
+          }
+
+          // face 센서 상태 업데이트
+          if (sensorData.face) {
+            const faceValue = sensorData.face.faceY !== undefined
+              ? Math.min(100, Math.max(0, Math.round(sensorData.face.faceY * 100)))
+              : undefined;
+
+            if (sensorData.face.status === 'normal') {
+              if (faceValue !== undefined) updateSensorValue('face', faceValue);
+            } else {
+              updateSensorStatus('face', sensorData.face.status, faceValue);
+            }
+          }
+        }
+
+        // speech_alert 토픽: 발화 키워드 감지 시 emotion 상태 업데이트
+        if (topic === 'speech_alert') {
+          const speechData = data as {
+            timestamp: number;
+            wardId: string;
+            speech: {
+              status: 'caution' | 'critical';
+              category: string;
+              categoryLabel: string;
+              matchedKeyword: string;
+              matchedKeywords: string[];
+              text: string;
+              matchCount: number;
+            };
+          };
+
+          if (speechData.speech) {
+            // 발화 키워드 감지 시 emotion 센서 상태를 caution/critical로 업데이트
+            const emotionValue = Math.round(speechData.speech.matchCount * 10); // matchCount 기반 값
+            updateSensorStatus('emotion', speechData.speech.status, Math.min(100, emotionValue));
+
+            console.log(
+              `[Sidebar] Speech alert: ${speechData.speech.categoryLabel} ` +
+              `keyword="${speechData.speech.matchedKeyword}" status=${speechData.speech.status}`
+            );
+          }
         }
       } catch (e) {
         console.error('[Sidebar] Failed to parse data packet:', e);
@@ -507,7 +1085,7 @@ export const ParticipantDetailSidebar = ({
     return () => {
       room.off(RoomEvent.DataReceived, handleData);
     };
-  }, [room, addTranscript]);
+  }, [room, addTranscript, updateSensorStatus, updateSensorValue]);
 
   // Auto-scroll to latest message
   useEffect(() => {
@@ -546,7 +1124,7 @@ export const ParticipantDetailSidebar = ({
           width: 'min(420px, 90vw)',
           height: isHeaderHidden ? '100vh' : 'calc(100vh - var(--header-height, 64px))',
           background: 'linear-gradient(180deg, #F7F9F2 0%, #F0F5E8 70%)',
-          borderLeft: '1px solid rgba(148,163,184,0.35)',
+          borderLeft: effectiveRiskLevel !== 'normal' ? `3px solid ${sidebarBorderColor}` : '1px solid rgba(148,163,184,0.35)',
           zIndex: 70,
           color: '#4A5D23',
           boxShadow: '-40px 0 80px rgba(15, 23, 42, 0.15)',
@@ -602,6 +1180,11 @@ export const ParticipantDetailSidebar = ({
               }}
             />
           </div>
+        </div>
+
+        {/* 센서 상태 표시 */}
+        <div style={{ padding: '16px 32px 0 32px', flexShrink: 0 }}>
+          <SensorStatusIndicator states={sensorStates} onUnlock={unlockSensor} />
         </div>
 
         {/* Content */}
@@ -914,8 +1497,7 @@ export const ParticipantDetailSidebar = ({
                         error,
                       );
                       alert(
-                        `대상자 정보를 불러오는데 실패했습니다.\n\nParticipant: ${participant.name}\nRoom: ${roomName || 'N/A'}\n\n${
-                          error instanceof Error ? error.message : String(error)
+                        `대상자 정보를 불러오는데 실패했습니다.\n\nParticipant: ${participant.name}\nRoom: ${roomName || 'N/A'}\n\n${error instanceof Error ? error.message : String(error)
                         }`,
                       );
                     } finally {
@@ -1048,7 +1630,7 @@ export const ParticipantDetailSidebar = ({
                             </span>
                           </div>
                           {/* Highlight danger keywords in text */}
-                          {highlightDangerKeywords(t.text)}
+                          {highlightDangerKeywords(t.text, detectedKeywords)}
                         </div>
                       </div>
                     );
@@ -1132,8 +1714,8 @@ export const ParticipantDetailSidebar = ({
             {isTakeoverActive ? '통화 종료' : '긴급 통화 개입'}
           </button>
 
-          {/* Clear Danger Button */}
-          {isDanger && (
+          {/* Clear Danger Button - shown for both danger and caution states */}
+          {(isDanger || riskLevel === 'caution') && (
             <button
               style={{
                 width: '100%',
@@ -1167,7 +1749,7 @@ export const ParticipantDetailSidebar = ({
               }}
             >
               <AlertTriangle size={16} />
-              위험 상태 해제
+              경고 상태 해제
             </button>
           )}
 

--- a/components/video/RoomTracks.tsx
+++ b/components/video/RoomTracks.tsx
@@ -15,6 +15,7 @@ import type { MockParticipant } from './ParticipantSidebar';
 export interface RoomDangerState {
   isDanger: boolean;
   dangerCode: string;
+  riskLevel?: 'normal' | 'caution' | 'critical';
 }
 
 export interface RoomTracksProps {
@@ -26,6 +27,7 @@ export interface RoomTracksProps {
   focusedParticipantId?: string | null;
   isFullscreenActive?: boolean;
   isDanger?: boolean;
+  riskLevel?: 'normal' | 'caution' | 'critical';
 }
 
 const getParticipantId = (participant: any) =>
@@ -62,6 +64,7 @@ export const RoomTracks = ({
   focusedParticipantId,
   isFullscreenActive,
   isDanger,
+  riskLevel,
 }: RoomTracksProps) => {
   // Get room metadata for danger state
   const roomInfo = useRoomInfo();
@@ -70,7 +73,7 @@ export const RoomTracks = ({
   useEffect(() => {
     if (!onDangerStateChange) return;
 
-    let dangerState: RoomDangerState = { isDanger: false, dangerCode: '0000' };
+    let dangerState: RoomDangerState = { isDanger: false, dangerCode: '0000', riskLevel: 'normal' };
 
     if (roomInfo.metadata) {
       try {
@@ -78,6 +81,7 @@ export const RoomTracks = ({
         dangerState = {
           isDanger: metadata.isDanger ?? false,
           dangerCode: metadata.dangerCode ?? '0000',
+          riskLevel: metadata.riskLevel ?? (metadata.isDanger ? 'critical' : 'normal'),
         };
       } catch {
         // Invalid metadata JSON, use defaults
@@ -265,6 +269,7 @@ export const RoomTracks = ({
             onClick={onTileClick}
             participantId={identity}
             isDanger={isDanger}
+            riskLevel={riskLevel}
           />
         );
       })}

--- a/hooks/useLocationDangerSSE.ts
+++ b/hooks/useLocationDangerSSE.ts
@@ -1,0 +1,172 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { API_BASE } from '../lib/api-client';
+
+type RiskLevel = 'normal' | 'caution' | 'critical';
+
+export interface LocationDangerState {
+  isDanger: boolean;
+  riskLevel: RiskLevel;
+  alertType?: string;
+  timestamp: number;
+}
+
+// Map riskLevel to location status
+// caution → warning, critical → emergency
+export function riskLevelToStatus(riskLevel: RiskLevel): 'normal' | 'warning' | 'emergency' {
+  switch (riskLevel) {
+    case 'critical':
+      return 'emergency';
+    case 'caution':
+      return 'warning';
+    default:
+      return 'normal';
+  }
+}
+
+// Reconnection constants
+const INITIAL_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 30000;
+const RETRY_MULTIPLIER = 2;
+
+interface UseLocationDangerSSEOptions {
+  enabled?: boolean;
+}
+
+/**
+ * SSE hook for real-time location danger state updates.
+ * Listens to room-danger events and maps them to wardId for location markers.
+ */
+export function useLocationDangerSSE({ enabled = true }: UseLocationDangerSSEOptions = {}) {
+  // wardId -> LocationDangerState
+  const [dangerStates, setDangerStates] = useState<Record<string, LocationDangerState>>({});
+  const [connected, setConnected] = useState(false);
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const retryDelayRef = useRef(INITIAL_RETRY_DELAY_MS);
+  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const mountedRef = useRef(true);
+
+  const connectSSE = useCallback(() => {
+    if (!enabled || !API_BASE || !mountedRef.current) return;
+
+    // Clean up existing connection
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+
+    const sseUrl = `${API_BASE}/v1/events/stream`;
+    console.log(`[useLocationDangerSSE] Connecting to SSE: ${sseUrl}`);
+
+    const eventSource = new EventSource(sseUrl);
+    eventSourceRef.current = eventSource;
+
+    eventSource.onopen = () => {
+      console.log('[useLocationDangerSSE] SSE connection opened');
+      setConnected(true);
+      retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
+    };
+
+    eventSource.onmessage = event => {
+      try {
+        const data = JSON.parse(event.data);
+
+        // Only handle room-danger events
+        if (data.type === 'room-danger' && data.wardId) {
+          console.log('[useLocationDangerSSE] Room danger event:', data.wardId, data.isDanger, data.riskLevel);
+
+          setDangerStates(prev => {
+            if (data.isDanger) {
+              return {
+                ...prev,
+                [data.wardId]: {
+                  isDanger: true,
+                  riskLevel: data.riskLevel || 'critical',
+                  alertType: data.alertType,
+                  timestamp: Date.now(),
+                },
+              };
+            } else {
+              // Remove danger state when cleared
+              const { [data.wardId]: _, ...rest } = prev;
+              return rest;
+            }
+          });
+        }
+      } catch (err) {
+        console.error('[useLocationDangerSSE] Failed to parse SSE event:', err);
+      }
+    };
+
+    eventSource.onerror = () => {
+      console.warn('[useLocationDangerSSE] SSE connection error, will reconnect...');
+      setConnected(false);
+      eventSource.close();
+      eventSourceRef.current = null;
+
+      // Schedule reconnection with exponential backoff
+      if (mountedRef.current) {
+        const delay = retryDelayRef.current;
+        console.log(`[useLocationDangerSSE] Reconnecting in ${delay}ms...`);
+
+        retryTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) {
+            connectSSE();
+          }
+        }, delay);
+
+        retryDelayRef.current = Math.min(
+          retryDelayRef.current * RETRY_MULTIPLIER,
+          MAX_RETRY_DELAY_MS
+        );
+      }
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!enabled || !API_BASE) {
+      console.log('[useLocationDangerSSE] SSE disabled or no API_BASE');
+      return;
+    }
+
+    connectSSE();
+
+    return () => {
+      console.log('[useLocationDangerSSE] Cleaning up SSE connection');
+      mountedRef.current = false;
+
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
+        retryTimeoutRef.current = null;
+      }
+
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    };
+  }, [enabled, connectSSE]);
+
+  /**
+   * Get the effective status for a ward, considering SSE danger state.
+   * SSE state takes priority over API-fetched state.
+   */
+  const getEffectiveStatus = useCallback(
+    (wardId: string, apiStatus: 'normal' | 'warning' | 'emergency'): 'normal' | 'warning' | 'emergency' => {
+      const dangerState = dangerStates[wardId];
+      if (dangerState?.isDanger) {
+        return riskLevelToStatus(dangerState.riskLevel);
+      }
+      return apiStatus;
+    },
+    [dangerStates]
+  );
+
+  return {
+    dangerStates,
+    connected,
+    getEffectiveStatus,
+  };
+}

--- a/utils/roomApi.ts
+++ b/utils/roomApi.ts
@@ -151,3 +151,43 @@ export const muteAgentInRoom = async (
     console.error('[muteAgentInRoom] Failed:', err);
   }
 };
+
+/**
+ * Acknowledge all alerts in a room via API
+ * Calls: PATCH /v1/guardians/alerts/acknowledge-all
+ */
+export const acknowledgeAllAlertsInRoom = async (
+  roomName: string,
+): Promise<void> => {
+  const apiBase = getApiBase();
+  const adminToken = getAdminToken();
+
+  if (!adminToken) {
+    console.warn('[acknowledgeAllAlertsInRoom] No admin token available');
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `${apiBase}/v1/guardians/alerts/acknowledge-all`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({ roomName }),
+      },
+    );
+
+    if (!response.ok) {
+      console.error('[acknowledgeAllAlertsInRoom] API error:', response.status);
+    } else {
+      console.log(
+        `[acknowledgeAllAlertsInRoom] All alerts acknowledged in ${roomName}`,
+      );
+    }
+  } catch (err) {
+    console.error('[acknowledgeAllAlertsInRoom] Failed:', err);
+  }
+};


### PR DESCRIPTION
## Summary
- 지도 페이지에서 care alert (caution/critical) 상태가 실시간으로 마커에 반영되도록 SSE 연동 추가
- 모니터링 페이지와 지도 페이지 동시 사용 시 양쪽에서 상태 동기화

## Changes
- `useLocationDangerSSE` hook 신규 추가
- `/locations` 페이지 SSE 연동
- `LiveTileOps`, `FullScreenVideo`, `ParticipantDetailSidebar`에 riskLevel prop 추가
- 개별 센서 dismiss 기능 (`acknowledge-by-type` API)
- isDanger 해제 시 센서 상태 자동 리셋

## Status Mapping
| riskLevel | location status | 마커 색상 |
|-----------|-----------------|-----------|
| critical | emergency | 🔴 빨강 |
| caution | warning | 🟡 노랑 |
| normal | normal | 기본 |

## Test plan
- [ ] 모니터링 + 지도 페이지 동시 오픈
- [ ] care alert 발생 시 양쪽 동시 반영 확인
- [ ] alert 해제 시 양쪽 동시 복귀 확인
- [ ] 개별 센서 dismiss 동작 확인

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)