### PR TITLE
[#167] adaptiveStream 비활성화 테스트

### DIFF
--- a/app/monitoring/page.tsx
+++ b/app/monitoring/page.tsx
@@ -603,7 +603,7 @@ export default function Home() {
 
   const liveKitOptions = {
     // Adaptive Bitrate: 네트워크 상태에 따라 자동 품질 조절
-    adaptiveStream: true,
+    adaptiveStream: false,
     audioCaptureDefaults: {
       autoGainControl: true,
       echoCancellation: true,

--- a/components/video/FullScreenVideo.tsx
+++ b/components/video/FullScreenVideo.tsx
@@ -342,6 +342,8 @@ export const FullScreenVideo = ({
       let bytesReceived = 0;
       let freezeCountDelta = 0;
       let totalFreezesDuration = 0;
+      let frameWidth = 0;
+      let frameHeight = 0;
 
       try {
         const receiver = (track as any)?.receiver;
@@ -358,12 +360,17 @@ export const FullScreenVideo = ({
               freezeCountDelta = (report.freezeCount || 0) - freezeCount;
               freezeCount = report.freezeCount || 0;
               totalFreezesDuration = report.totalFreezesDuration || 0;
+              frameWidth = report.frameWidth || 0;
+              frameHeight = report.frameHeight || 0;
             }
           });
         }
       } catch (e) {
         // stats 접근 실패 시 무시
       }
+
+      // 실제 수신 해상도
+      const resolution = `${frameWidth}x${frameHeight}`;
 
       // 프레임 드랍/freeze 감지
       const framesDelta = framesReceived - lastFramesReceived;
@@ -396,8 +403,8 @@ export const FullScreenVideo = ({
         subscribed: pub.subscribed,
         videoQuality: qualityNames[pub.videoQuality] || pub.videoQuality,
         isMuted: pub.isMuted,
-        // 해상도
-        dimensions: track?.dimensions ? `${track.dimensions.width}x${track.dimensions.height}` : 'unknown',
+        // 실제 수신 해상도
+        resolution,
         // 연결 상태
         connectionQuality: connectionNames[remoteParticipant.connectionQuality] || remoteParticipant.connectionQuality,
         roomState: room.state,


### PR DESCRIPTION
## 요약
- 모니터링 페이지에서 adaptiveStream을 비활성화하여 품질 강제 동작을 확인
- Fullscreen 수신 해상도 로그를 보강

## 변경 사항
- adaptiveStream: true → false
- WebRTC 통계 로그에 실제 수신 해상도(resolution) 출력

## 테스트
- 미실행 (브라우저에서 새로고침 후 로그 확인 필요)
